### PR TITLE
`linux-gnu`* => `linux`*

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -53,7 +53,7 @@ EOM
 platform=''
 machine=$(uname -m)
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+if [[ "$OSTYPE" == "linux"* ]]; then
   if [[ "$machine" == "arm"* || "$machine" == "aarch"* ]]; then
     platform='linux-arm'
   elif [[ "$machine" == *"86" ]]; then


### PR DESCRIPTION
Quick fix for openSUSE (and other distros), issue #6
(linux* will also cover linux-gnu*, so no need for `or` statement)