### PR TITLE
Remove unnecessary variable definition

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -25,30 +25,6 @@ function githubLatestTag {
     echo "${finalUrl##*v}"
 }
 
-UNKNOWN_OS_MSG=<<-'EOM'
-/=====================================\
-|      COULD NOT DETECT PLATFORM      |
-\=====================================/
-
-Uh oh! We couldn't automatically detect your operating system. You can file a
-bug here: https://github.com/benweissmann/getmic.ro
-
-To continue with installation, please choose from one of the following values:
-
-- freebsd32
-- freebsd64
-- linux-arm
-- linux32
-- linux64
-- netbsd32
-- netbsd64
-- openbsd32
-- openbsd64
-- osx
-- win32
-- win64
-EOM
-
 
 platform=''
 machine=$(uname -m)


### PR DESCRIPTION
I was looking at the install script and I found that the `UNKNOWN_OS_MSG` ([line 28](https://github.com/benweissmann/getmic.ro/blob/fe88b65b2bc0bf0332f27de98293c314ce92df3d/index.sh#L28)) is never used. As such, it can be removed to make the script marginally smaller.