### PR TITLE
Adding Micro to the system list of console editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ While getmic.ro is tested primarily with bash, it should be compatible with any 
 
 ### Verify the script checksum
 
-To verify the script, you can download it and checksum it. The sha256 checksum is `08c2651500958d2c79e96b4fab4629cdca8c9d07f916b81e5fabae961657f4de`.
+To verify the script, you can download it and checksum it. The sha256 checksum is `fa1ab666f08a5ad8221531b31a3365f1d5a756c9f851bcce6ae558ff8de777ee`.
 
     curl -o getmicro.sh https://getmic.ro
-    shasum -a 256 getmicro.sh # and check the output
+    if [ "$(shasum -a 256 getmicro.sh)" # and check the output
     bash getmicro.sh
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ While getmic.ro is tested primarily with bash, it should be compatible with any 
 To verify the script, you can download it and checksum it. The sha256 checksum is `fa1ab666f08a5ad8221531b31a3365f1d5a756c9f851bcce6ae558ff8de777ee`.
 
     curl -o getmicro.sh https://getmic.ro
-    if [ "$(shasum -a 256 getmicro.sh)" # and check the output
+    shasum -a 256 getmicro.sh # and check the output
     bash getmicro.sh
 
 ## Contributing

--- a/index.sh
+++ b/index.sh
@@ -119,10 +119,10 @@ installAlternativeEditor() {
   # add micro as an editor alternative
   altlink="$(update-alternatives --query editor | grep Link | cut -f 2 -d " ")"
   printf "Installing Micro as an alternative %s at: %s\n" "$altlink" "$directory"
-  sudo update-alternatives --install "$altlink" editor "$directory/micro" 80
+  sudo update-alternatives --install "$altlink" editor "$directory/micro" 80 2> /dev/null
 }
 checkForExistingInstall() {
-  return $(printf "%s" "$otherEditors" | grep -x -e "$directory/micro" -e "$absolute/micro" -c 2> /dev/null)
+  return "$(printf "%s" "$otherEditors" | grep -x -e "$directory/micro" -e "$absolute/micro" -c 2> /dev/null)"
 }
 otherEditors=
 if command -v update-alternatives > /dev/null; then

--- a/index.sh
+++ b/index.sh
@@ -111,6 +111,44 @@ mv "micro-$TAG/micro" ./micro
 rm micro.tar.gz
 rm -rf "micro-$TAG"
 
+
+
+# Next, add micro as an official editor in Linux systems if we are on the path
+
+installAlternativeEditor() {
+  # add micro as an editor alternative
+  altlink="$(update-alternatives --query editor | grep Link | cut -f 2 -d " ")"
+  printf "Installing Micro as an alternative %s at: %s\n" "$altlink" "$directory"
+  sudo update-alternatives --install "$altlink" editor "$directory/micro" 80
+}
+checkForExistingInstall() {
+  return $(printf "%s" "$otherEditors" | grep -x -e "$directory/micro" -e "$absolute/micro" -c 2> /dev/null)
+}
+otherEditors=
+if command -v update-alternatives > /dev/null; then
+  # NOTE that this is purposely variable assignment instead of comparison
+  if otherEditors="$(update-alternatives --list editor 2> /dev/null)"; then
+    # Use absolute path for the directory if a relative path was specified.
+    directory="$(pwd)"
+    absolute="$directory"
+    if command -v readlink >/dev/null ; then
+      absolute="$(readlink -f "$directory")"
+    elif command -v realpath >/dev/null ; then
+      absolute="$(realpath "$directory")"
+    fi
+    
+    if checkForExistingInstall; then
+      case ":$PATH:" in
+        *:"$directory":*) installAlternativeEditor;;
+        *:"$absolute":*) installAlternativeEditor;;
+        *) ;;
+      esac
+    fi
+  fi
+fi
+
+
+
 cat <<-'EOM'
 
  __  __ _                  ___           _        _ _          _ _


### PR DESCRIPTION
Update-alternatives provides an excellent way to offer Micro as a console text editor drop-in replacement for other console editors. This change is not biased against other Linux distros. This fix merely provides a huge convenience feature for all distros which support update-alternatives.