### PR TITLE
Add support for win32/win64 platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, macOS-latest]
+        os: [ubuntu-latest, ubuntu-16.04, macOS-latest, windows-latest]
     steps:
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Test
       run: ./ci/runTest.sh
+      shell: bash
 
   lint:
     name: Lint

--- a/ci/runTest.sh
+++ b/ci/runTest.sh
@@ -21,3 +21,11 @@ export GETMICRO_PLATFORM=linux32
 export GETMICRO_PLATFORM=linux64
 (cat index.sh | "$shell" | grep 'Detected platform: linux64') || \
   (echo 'Fail: linux64 override test' && exit 1)
+
+export GETMICRO_PLATFORM=win32
+(cat index.sh | "$shell" | grep 'Detected platform: win32') || \
+  (echo 'Fail: win32 override test' && exit 1)
+
+export GETMICRO_PLATFORM=win64
+(cat index.sh | "$shell" | grep 'Detected platform: win64') || \
+  (echo 'Fail: win64 override test' && exit 1)

--- a/index.sh
+++ b/index.sh
@@ -28,8 +28,8 @@ machine=$(uname -m)
 if [ "${GETMICRO_PLATFORM:-x}" != "x" ]; then
   platform="$GETMICRO_PLATFORM"
 else
-  case "$(uname -s)" in
-    "Linux")
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    "linux")
       case "$machine" in
         "arm64"* | "aarch64"* ) platform='linux-arm64' ;;
         "arm"* | "aarch"*) platform='linux-arm' ;;
@@ -37,23 +37,29 @@ else
         *"64") platform='linux64' ;;
       esac
       ;;
-    "Darwin") platform='osx' ;;
-    *"FreeBSD"*)
+    "darwin") platform='osx' ;;
+    *"freebsd"*)
       case "$machine" in
         *"86") platform='freebsd32' ;;
         *"64") platform='freebsd64' ;;
       esac
       ;;
-    "OpenBSD")
+    "openbsd")
       case "$machine" in
         *"86") platform='openbsd32' ;;
         *"64") platform='openbsd64' ;;
       esac
       ;;
-    "NetBSD")
+    "netbsd")
       case "$machine" in
         *"86") platform='netbsd32' ;;
         *"64") platform='netbsd64' ;;
+      esac
+      ;;
+    "msys"*|"cygwin"*|"mingw"*|*"_nt"*|"win"*)
+      case "$machine" in
+        *"86") platform='win32' ;;
+        *"64") platform='win64' ;;
       esac
       ;;
   esac
@@ -100,15 +106,25 @@ fi
 
 TAG=$(githubLatestTag zyedidia/micro)
 
+if [ "x$platform" = "xwin64" ] || [ "x$platform" = "xwin32" ]; then
+  extension='zip'
+else
+  extension='tar.gz'
+fi
+
 printf "Latest Version: %s\n" "$TAG"
-printf "Downloading https://github.com/zyedidia/micro/releases/download/v%s/micro-%s-%s.tar.gz\n" "$TAG" "$TAG" "$platform"
+printf "Downloading https://github.com/zyedidia/micro/releases/download/v%s/micro-%s-%s.%s\n" "$TAG" "$TAG" "$platform" "$extension"
 
-curl -L "https://github.com/zyedidia/micro/releases/download/v$TAG/micro-$TAG-$platform.tar.gz" > micro.tar.gz
+curl -L "https://github.com/zyedidia/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension" > "micro.$extension"
 
-tar -xvzf micro.tar.gz "micro-$TAG/micro"
+case "$extension" in
+  "zip") unzip -j "micro.$extension" -d "micro-$TAG" ;;
+  "tar.gz") tar -xvzf "micro.$extension" "micro-$TAG/micro" ;;
+esac
+
 mv "micro-$TAG/micro" ./micro
 
-rm micro.tar.gz
+rm "micro.$extension"
 rm -rf "micro-$TAG"
 
 cat <<-'EOM'


### PR DESCRIPTION
## Description

Fixes #21. Add detection for Windows platform (ref. [1](https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_env.bash#L22), [2](https://stackoverflow.com/a/27776822), [3](https://gist.github.com/prabirshrestha/3080525)) and installation as `micro` win32/win64 releases are `zip` files and not `tar.gz` like the others.

`shell: bash` was add to the `test.yml` file so Github Actions runner use [bash shell included with Git for Windows](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell) on Windows platforms.

## How Has This Been Tested?

Ran updated `./install.sh` script on `win64` (Windows 10 v.19041 with Git Bash) and linux64 (Ubuntu 18.04).
Run Github Actions automated tests on forked repo.


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If I added new user-facing functionality, I have made corresponding changes to the README documenting the changes
- [x] If this is a code change, I have updated the [test configuration](https://github.com/benweissmann/getmic.ro/blob/master/.github/workflows/test.yml) and/or [test scripts](https://github.com/benweissmann/getmic.ro/tree/master/ci) to cover the changes I've made.
