### PR TITLE
Fix freebsd32 test

### DIFF
--- a/testboxes/freebsd32/Vagrantfile
+++ b/testboxes/freebsd32/Vagrantfile
@@ -12,7 +12,8 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/freebsd-11.1-i386"
+  config.vm.box = "bento/freebsd-12.1-i386"
+  config.vm.box_version = "201912.14.0"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
@@ -67,9 +68,9 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    export PKG_VERSION=`fetch -qo - https://pkg.freebsd.org/FreeBSD:11:i386/latest/All/ | grep -o 'href="pkg-1\\.[0-9.]\\+.txz"' | grep -o 'pkg-[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+'`
-    IGNORE_OSVERSION=yes pkg add -f https://pkg.freebsd.org/FreeBSD:11:i386/latest/All/$PKG_VERSION.txz
+    pkg bootstrap -f
     IGNORE_OSVERSION=yes pkg update -f
+    IGNORE_OSVERSION=yes pkg upgrade -fy
     pkg install -y bash curl
     ln -sf /lib/libc.so.7 /usr/lib/libdl.so.1
   SHELL


### PR DESCRIPTION
## Description

Update freebsd32 Vagrantfile to fix freebsd32 test.

Test "Test on testboxes/freebsd32 with Vagrant" would fail because it was trying to access a subfolder index on `https://pkg.freebsd.org` but was getting `403 Forbidden` response:

```
    default: https://pkg.freebsd.org/FreeBSD:11:i386/latest/All/: Forbidden
    default: pkg: 
    default: https://pkg.freebsd.org/FreeBSD:11:i386/latest/All/.txz: Not Found
```

The permissions on the subfolders was probably recently updated as it is clarified here [https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247998](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247998)

The line was trying to install the `pkg` package. It also can be achieved using `pkg bootstrap -f` (pkg or `pkg-static install -f pkg` (ref. [1](https://forums.FreeBSD.org/threads/pkg-update-error.74260/post-458694)).

[pkg man page](https://www.freebsd.org/cgi/man.cgi?pkg(7)) quote regarding `pkg bootstrap`:

```
pkg bootstrap [-f]
		    Attempt to bootstrap and do	not forward anything to	pkg(8)
		    after it is	installed.  If the -f flag is specified, then
		    pkg(8) will	be fetched and installed regardless if it is
		    already installed.
```


## How Has This Been Tested?

Ran Github Actions automated tests on forked repo.


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If I added new user-facing functionality, I have made corresponding changes to the README documenting the changes
- [x] If this is a code change, I have updated the [test configuration](https://github.com/benweissmann/getmic.ro/blob/master/.github/workflows/test.yml) and/or [test scripts](https://github.com/benweissmann/getmic.ro/tree/master/ci) to cover the changes I've made.
