### PR TITLE
index.sh: Remove `linux64-static` override

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         os:
         - ubuntu-24.04
-        - macos-13
         - macos-14
+        - macos-15
         - windows-2022
         update_alternatives:
         - y

--- a/README.fr.md
+++ b/README.fr.md
@@ -60,16 +60,16 @@ wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" GETMICRO_PLATFORM=linux32 
 
 ### Vérifier la somme de contrôle (checksum)
 
-Pour vérifer le script, vous pouvez le télécharger et chercher sa somme de contrôle. Le sha256 est `60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e`.
+Pour vérifer le script, vous pouvez le télécharger et chercher sa somme de contrôle. Le sha256 est `4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9`.
 
 ```Bash
-gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e ] && echo "$gmcr" | sh
+gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9 ] && echo "$gmcr" | sh
 ```
 
 Ou:
 
 ```Bash
-# 1. Vérifiez manuellement que cette sortie 60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e
+# 1. Vérifiez manuellement que cette sortie 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9
 curl https://getmic.ro | shasum -a 256
 
 # 2. Si #1 a réussi, exécutez getmicro

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" GETMICRO_PLATFORM=linux32 
 
 ### Verify the script checksum
 
-To verify the script, you can download it and checksum it. The sha256 checksum is `60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e`.
+To verify the script, you can download it and checksum it. The sha256 checksum is `4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9`.
 
 ```Bash
-gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e ] && echo "$gmcr" | sh
+gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9 ] && echo "$gmcr" | sh
 ```
     
 Alternatively, you can use the following manual method.
 
 ```Bash
-# 1. Manually verify that this outputs 60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e
+# 1. Manually verify that this outputs 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9
 curl https://getmic.ro | shasum -a 256
 
 # 2. If #1 was successful, then execute getmicro
@@ -105,5 +105,3 @@ If you're not sure how to do any of these things, feel free to open a PR with yo
 - Loosely based on the Chef curl|bash: https://docs.chef.io/install_omnibus.html
 
 - ASCII art courtesy of figlet: http://www.figlet.org/
-
-<!--shasum=60ef856d3c2bd1b2ffdbc150340595095f10913d3e2bd1543950fb6fe150380e-->

--- a/index.sh
+++ b/index.sh
@@ -200,15 +200,6 @@ else
   extension='tar.gz'
 fi
 
-if [ "${platform:-x}" = "linux64" ]; then
-  # Detect musl libc (source: https://stackoverflow.com/a/60471114)
-  libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
-  if [ -n "$libc" ]; then
-    # Musl libc; use the staticly-compiled versioon
-    platform='linux64-static'
-  fi
-fi
-
 echo "Latest Version: $TAG"
 echo "Downloading https://github.com/zyedidia/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension"
 


### PR DESCRIPTION
## Description

The linux64-static override can be dropped since micro's binary files will be build fully static in the future (see: zyedidia/micro#3466).
Due to this there is no need for a musl libc check and the override of linux64 with linux64-static.

Unfortunately this will take effect earliest with the upcoming release.

## How Has This Been Tested?

```shell
$ ldd micro
  das Programm ist nicht dynamisch gelinkt
```

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If I added new user-facing functionality, I have made corresponding changes to the README documenting the changes
- [x] If this is a code change, I have updated the [test configuration](https://github.com/benweissmann/getmic.ro/blob/master/.github/workflows/test.yml) and/or [test scripts](https://github.com/benweissmann/getmic.ro/tree/master/ci) to cover the changes I've made.
