### PR TITLE
Add macos-arm64 arch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         os:
         - ubuntu-24.04
-        - macos-12
+        - macos-13
+        - macos-14
         - windows-2022
         update_alternatives:
         - y

--- a/README.fr.md
+++ b/README.fr.md
@@ -42,7 +42,7 @@ Vous pouvez aussi faire d'autres choses avec getmic.ro. La documentation França
 * `GETMICRO_HTTP=<COMMAND ...ARGS>`
     + Exemple: `curl https://getmic.ro | GETMICRO_HTTP="curl -L" sh`
     + Exemple: `wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" sh`
-* `GETMICRO_PLATFORM=[freebsd32 | freebsd64 linux-arm | linux-arm64 | linux32 | linux64 | linux64-static | netbsd32 | netbsd64 | openbsd32 | openbsd64 | osx | win32 | win64]`
+* `GETMICRO_PLATFORM=[freebsd32 | freebsd64 linux-arm | linux-arm64 | linux32 | linux64 | linux64-static | macos-arm64 | netbsd32 | netbsd64 | openbsd32 | openbsd64 | osx | win32 | win64]`
     + Par défaut: `GETMICRO_PLATFORM=n`
     + Par exemple, si votre libc est musl, alors: `https://getmic.ro | GETMICRO_PLATFORM=linux64-static sh`
 * `GETMICRO_REGISTER=[y | n]`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There's a couple other things you can do with getmic.ro. Listed below are enviro
         - It IS OPTIONAL for the command to also accept a `--header` parameter used for non-essential GitHub authentication fallback shim.
     + For example, to force using `curl`, do: `curl https://getmic.ro | GETMICRO_HTTP="curl -L" sh`
     + For example, to force using `wget`, do: `wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" sh`
-* `GETMICRO_PLATFORM=[freebsd32 | freebsd64 linux-arm | linux-arm64 | linux32 | linux64 | linux64-static | netbsd32 | netbsd64 | openbsd32 | openbsd64 | osx | win32 | win64]`
+* `GETMICRO_PLATFORM=[freebsd32 | freebsd64 linux-arm | linux-arm64 | linux32 | linux64 | linux64-static | macos-arm64 | netbsd32 | netbsd64 | openbsd32 | openbsd64 | osx | win32 | win64]`
     + This manually overrides the platform detection mechanism and downloads the binaries for the platform you specify
     + One usage of this is specifying `https://getmic.ro | GETMICRO_PLATFORM=linux64-static sh` when using an incompatible libc implementation such as musl.
 * `GETMICRO_REGISTER=[y | n]`

--- a/index.sh
+++ b/index.sh
@@ -101,7 +101,12 @@ else
         *"64") platform='linux64' ;;
       esac
       ;;
-    "darwin") platform='osx' ;;
+    "darwin") 
+      case "$machine" in
+        "arm64") platform='macos-arm64' ;;
+        "x86_64") platform='osx' ;;
+	  esac
+	  ;;
     *"freebsd"*)
       case "$machine" in
         *"86") platform='freebsd32' ;;
@@ -146,6 +151,7 @@ To continue with installation, please choose from one of the following values:
 - linux-arm64
 - linux32
 - linux64
+- macos-arm64
 - netbsd32
 - netbsd64
 - openbsd32

--- a/index.sh
+++ b/index.sh
@@ -104,7 +104,7 @@ else
     "darwin") 
       case "$machine" in
         "arm64") platform='macos-arm64' ;;
-        "x86_64") platform='osx' ;;
+        *) platform='osx' ;;
 	  esac
 	  ;;
     *"freebsd"*)


### PR DESCRIPTION
## Description

My pr adds support for macos-arm64 release, so micro installed via the script doesn't require rosetta to run.
I've also modified the test workflow to run on macos-13 and macos-14 instead of just macos-12.
I've also added `macos-arm64` as a valid release in both the error message and readme (respecting the alphabetical order).

## How Has This Been Tested?

I've ran the updated script on an intel mac and on an arm mac, and it worked.
My changes have also passed existing tests.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If I added new user-facing functionality, I have made corresponding changes to the README documenting the changes
- [x] If this is a code change, I have updated the [test configuration](https://github.com/benweissmann/getmic.ro/blob/master/.github/workflows/test.yml) and/or [test scripts](https://github.com/benweissmann/getmic.ro/tree/master/ci) to cover the changes I've made.
