### PR TITLE
Change `zyedidia/micro` to `micro-editor/micro`

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -60,16 +60,16 @@ wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" GETMICRO_PLATFORM=linux32 
 
 ### Vérifier la somme de contrôle (checksum)
 
-Pour vérifer le script, vous pouvez le télécharger et chercher sa somme de contrôle. Le sha256 est `4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9`.
+Pour vérifer le script, vous pouvez le télécharger et chercher sa somme de contrôle. Le sha256 est `d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35`.
 
 ```Bash
-gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9 ] && echo "$gmcr" | sh
+gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35 ] && echo "$gmcr" | sh
 ```
 
 Ou:
 
 ```Bash
-# 1. Vérifiez manuellement que cette sortie 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9
+# 1. Vérifiez manuellement que cette sortie d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35
 curl https://getmic.ro | shasum -a 256
 
 # 2. Si #1 a réussi, exécutez getmicro

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ wget -O- https://getmic.ro | GETMICRO_HTTP="wget -O-" GETMICRO_PLATFORM=linux32 
 
 ### Verify the script checksum
 
-To verify the script, you can download it and checksum it. The sha256 checksum is `4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9`.
+To verify the script, you can download it and checksum it. The sha256 checksum is `d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35`.
 
 ```Bash
-gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9 ] && echo "$gmcr" | sh
+gmcr="$(curl https://getmic.ro)" && [ $(echo "$gmcr" | shasum -a 256 | cut -d' ' -f1) = d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35 ] && echo "$gmcr" | sh
 ```
 
 Alternatively, you can use the following manual method.
 
 ```Bash
-# 1. Manually verify that this outputs 4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9
+# 1. Manually verify that this outputs d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35
 curl https://getmic.ro | shasum -a 256
 
 # 2. If #1 was successful, then execute getmicro
@@ -106,4 +106,4 @@ If you're not sure how to do any of these things, feel free to open a PR with yo
 
 - ASCII art courtesy of figlet: http://www.figlet.org/
 
-<!--shasum=4b7b9d3062183f1010d5b0b919673ea532725d1fd01c875c29117905a3681fc9-->
+<!--shasum=d041f51b97871dc7de1f01879c12a978b074a5acdb6528e884ce8f4c05d2ad35-->

--- a/index.sh
+++ b/index.sh
@@ -173,7 +173,7 @@ else
   echo "Detected platform: $platform"
 fi
 
-TAG=$(githubLatestTag zyedidia/micro)
+TAG=$(githubLatestTag micro-editor/micro)
 
 if command -v grep >/dev/null 2>&1 ; then
   if ! echo "v$TAG" | grep -E '^v[0-9]+[.][0-9]+[.][0-9]+$' >/dev/null 2>&1 ; then
@@ -201,9 +201,9 @@ else
 fi
 
 echo "Latest Version: $TAG"
-echo "Downloading https://github.com/zyedidia/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension"
+echo "Downloading https://github.com/micro-editor/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension"
 
-eval "$http 'https://github.com/zyedidia/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension'" > "micro.$extension"
+eval "$http 'https://github.com/micro-editor/micro/releases/download/v$TAG/micro-$TAG-$platform.$extension'" > "micro.$extension"
 
 case "$extension" in
   "zip") unzip -j "micro.$extension" -d "micro-$TAG" ;;


### PR DESCRIPTION
## Description

[micro](https://github.com/micro-editor/micro) was recently moved into the [micro-editor](https://github.com/micro-editor) organization. This change shall use direct calls to the official URLs instead redirects performed by GitHub...which might not work in the future.

## How Has This Been Tested?

Just updated the SHA256 sum in the README's.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] If I added new user-facing functionality, I have made corresponding changes to the README documenting the changes
- [ ] If this is a code change, I have updated the [test configuration](https://github.com/benweissmann/getmic.ro/blob/master/.github/workflows/test.yml) and/or [test scripts](https://github.com/benweissmann/getmic.ro/tree/master/ci) to cover the changes I've made.
